### PR TITLE
Simple fix for wrong property name on job

### DIFF
--- a/views/dashboard/index.haml
+++ b/views/dashboard/index.haml
@@ -73,7 +73,7 @@
         = link_to( collection_path( :jobs ), 'View All Jobs' )
       - Backstage::Job.all.each do |job|
         .element
-          = link_to object_path( job ), "#{job.display_name} - #{job.app_name}"
+          = link_to object_path( job ), "#{job.name} - #{job.app_name}"
 
     #services.list
       %h3 Services


### PR DESCRIPTION
Fix issue where having job deployed broke the dashboard due to wrong property on job object

Wondering is there any way to make sinatra more resilient to errors (any view error seems to take the whole app down)
