### PR TITLE
- removed unnecessary quote which caused the start service link not to wo

### DIFF
--- a/lib/services/models/service.rb
+++ b/lib/services/models/service.rb
@@ -39,7 +39,7 @@ module Backstage
     end
     
     def available_actions
-      status == 'Started' ? %w{ stop } : %w{ start' }
+      status == 'Started' ? %w{ stop } : %w{ start }
     end
   end
 end


### PR DESCRIPTION
- removed unnecessary quote which caused the start service link not to work properly
