### PR TITLE
Construct new string from evaluate results

### DIFF
--- a/lib/pools/routes.rb
+++ b/lib/pools/routes.rb
@@ -27,8 +27,8 @@ module Backstage
       script = params[:script] || ''
       response = { :script => script }
       begin
-        result = object.evaluate( script )
-        response[:result] = result
+        result = object.evaluate( script ) || 'null'
+        response[:result] = String.new(result.to_s)
       rescue Exception => ex
         response[:exception] = ex
         response[:backtrace] = ex.backtrace


### PR DESCRIPTION
This resolves issue #33 by constructing a new String so the to_json will be the one from the current context (i.e. not the target application). It also seems best to do a to_s on the evaluate results so that any object (Hash, Array, etc) returned by the script can be displayed after evaluation.

There didn't seem to be any specs around this whole area. This could probably use some attention...
